### PR TITLE
tasks/system_probe.py: run the tests

### DIFF
--- a/pkg/dyninst/compiler/compile_test.go
+++ b/pkg/dyninst/compiler/compile_test.go
@@ -8,10 +8,30 @@
 package compiler
 
 import (
+	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
+var MinimumKernelVersion = kernel.VersionCode(5, 17, 0)
+
+func skipIfKernelNotSupported(t *testing.T) {
+	curKernelVersion, err := kernel.HostVersion()
+	require.NoError(t, err)
+	if curKernelVersion < MinimumKernelVersion {
+		t.Skipf("Kernel version %v is not supported", curKernelVersion)
+	}
+	if runtime.GOARCH != "amd64" {
+		t.Skipf("platform %v is not supported", runtime.GOARCH)
+	}
+}
+
 func TestCompileBPFProgram(t *testing.T) {
+	skipIfKernelNotSupported(t)
+
 	err := CompileBPFProgram()
 	if err != nil {
 		t.Fatalf("Failed to compile BPF program: %v", err)

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -55,6 +55,7 @@ TEST_PACKAGES_LIST = [
     "./pkg/collector/corechecks/servicediscovery/module/...",
     "./pkg/process/monitor/...",
     "./pkg/dynamicinstrumentation/...",
+    "./pkg/dyninst/...",
     "./pkg/gpu/...",
     "./pkg/system-probe/config/...",
     "./comp/metadata/inventoryagent/...",


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test reliability by skipping BPF program compilation tests on unsupported kernel versions or non-amd64 architectures.
  - Expanded system-probe test coverage to include additional package paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->